### PR TITLE
Correctly parse value in Bitstring32WithCP56Time2a_getFromBuffer

### DIFF
--- a/lib60870-C/src/iec60870/apl/information_objects.c
+++ b/lib60870-C/src/iec60870/apl/information_objects.c
@@ -1665,6 +1665,7 @@ Bitstring32WithCP56Time2a_getFromBuffer(Bitstring32WithCP56Time2a self, Connecti
         value += ((uint32_t)msg [startIndex++] * 0x100);
         value += ((uint32_t)msg [startIndex++] * 0x10000);
         value += ((uint32_t)msg [startIndex++] * 0x1000000);
+        self->value = value;
 
         /* quality */
         self->quality = (QualityDescriptor) msg [startIndex++];


### PR DESCRIPTION
In Bitstring32WithCP56Time2a_getFromBuffer the value was never written to the created object