### PR TITLE
Fix for shared lib target on windows: export table was empty

### DIFF
--- a/lib60870-C/src/CMakeLists.txt
+++ b/lib60870-C/src/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library (iec60870-shared SHARED ${library_SRCS} )
 set_target_properties(iec60870-shared PROPERTIES
            OUTPUT_NAME iec60870
            SOVERSION "${LIB_VERSION_MAJOR}.${LIB_VERSION_MINOR}.${LIB_VERSION_PATCH}"
+	   WINDOWS_EXPORT_ALL_SYMBOLS true
 )
 
 


### PR DESCRIPTION
I was trying to use the library in a Delphi project and found out that the resulting iec60870.dll had a empty export table. I checked the CMake docs and found an option to automatically generate export for all symbols.