### PR TITLE
Fix connection reset when message is not in one tcp fragment

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_connection.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_connection.c
@@ -496,13 +496,22 @@ receiveMessageSocket(Socket socket, uint8_t* buffer)
         return -1; /* message error */
 
     if (Socket_read(socket, buffer + 1, 1) != 1)
-        return -1;
+        return -2;
 
     int length = buffer[1];
 
     /* read remaining frame */
-    if (Socket_read(socket, buffer + 2, length) != length)
-        return -1;
+    int read_len = 0;
+    while (read_len < length)
+    {
+        int part_len = Socket_read(socket, buffer + 2 + read_len, length - read_len);
+        if (part_len < 0)  // indicates error
+            return -2;
+        read_len += part_len;
+    }
+
+    if (read_len != length)
+        return -3;
 
     return length + 2;
 }
@@ -737,7 +746,7 @@ handleConnection(void* parameter)
                 if (Handleset_waitReady(handleSet, 100)) {
                     int bytesRec = receiveMessage(self, buffer);
 
-                    if (bytesRec == -1) {
+                    if (bytesRec <= -1) {
                         loopRunning = false;
                         self->failure = true;
                     }


### PR DESCRIPTION
in receiveMessageSocket():
 return different illegal values for different cases
 -1: start byte not found
 -2: unable to read length
 -3: payload length does not match data length field

 Add while loop to call Socket_read multiple times until entire message
 is read, using read_len as index into buffer and using
 (length - read_len) as number of bytes to read

 allow early exit with error code when Socket_read returns an error

in handleConnection():
 handle any negative value in bytesRecv as error