### PR TITLE
Fix uninitialized queue

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_slave.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_slave.c
@@ -2527,6 +2527,17 @@ MasterConnection_create(CS104_Slave slave)
         self->sentASDUsLock = Semaphore_create(1);
 #endif
         self->handleSet = Handleset_new();
+
+        // initialize pointers with NULL to segmentation fault on destroy call
+        self->socket = NULL;
+#if (CONFIG_CS104_SUPPORT_TLS == 1)
+        self->tlsSocket = NULL;
+#endif
+#if (CONFIG_CS104_SUPPORT_SERVER_MODE_MULTIPLE_REDUNDANCY_GROUPS == 1)
+        self->redundancyGroup = NULL;
+#endif
+        self->lowPrioQueue = NULL;
+        self->highPrioQueue = NULL;
     }
 
     return self;

--- a/lib60870-C/src/iec60870/cs104/cs104_slave.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_slave.c
@@ -470,13 +470,16 @@ HighPriorityASDUQueue_create(int maxQueueSize)
 static void
 HighPriorityASDUQueue_destroy(HighPriorityASDUQueue self)
 {
-    GLOBAL_FREEMEM(self->buffer);
+    if (self){
+        if (self->buffer)
+            GLOBAL_FREEMEM(self->buffer);
 
 #if (CONFIG_USE_SEMAPHORES == 1)
-    Semaphore_destroy(self->queueLock);
+        Semaphore_destroy(self->queueLock);
 #endif
 
-    GLOBAL_FREEMEM(self);
+        GLOBAL_FREEMEM(self);
+    }
 }
 
 static void

--- a/lib60870-C/src/iec60870/cs104/cs104_slave.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_slave.c
@@ -2764,7 +2764,7 @@ handleClientConnections(CS104_Slave self)
         for (i = 0; i < CONFIG_CS104_MAX_CLIENT_CONNECTIONS; i++) {
             MasterConnection con = self->masterConnections[i];
 
-            if (con != NULL & con->isUsed) {
+            if (con != NULL && con->isUsed) {
                 if (con->isRunning)
                     MasterConnection_executePeriodicTasks(con);
             }


### PR DESCRIPTION
I have found another issue related to MODE: CONNECTION_IS_REDUNDANCY_GROUP.
If you create a slave (CS104_Slave_create) and destroy the slave (cs104_Slave_destroy) without calling start (CS104_Slave_start) inbetween it will produce a segmentation fault in trying to destroy the queue witch pointer was neither initialized with NULL nor instanciated (instantiation is done within the start function).