### PR TITLE
- Socket HAL (linux/bsd): Fix double-free in Socket_destroy() (see #56)

### DIFF
--- a/lib60870-C/src/hal/socket/bsd/socket_bsd.c
+++ b/lib60870-C/src/hal/socket/bsd/socket_bsd.c
@@ -438,6 +438,9 @@ Socket_destroy(Socket self)
 
     self->fd = -1;
 
+    if (fd == -1)
+        return;
+
     closeAndShutdownSocket(fd);
 
     Thread_sleep(10);

--- a/lib60870-C/src/hal/socket/linux/socket_linux.c
+++ b/lib60870-C/src/hal/socket/linux/socket_linux.c
@@ -453,6 +453,9 @@ Socket_destroy(Socket self)
 
     self->fd = -1;
 
+    if (fd == -1)
+        return;
+
     closeAndShutdownSocket(fd);
 
     Thread_sleep(10);


### PR DESCRIPTION
This may happen when Socket_destroy() is called several times for same Socket.

Fixes https://github.com/mz-automation/lib60870/issues/56