### PR TITLE
- CS104 connection: Fix use-after-free in handleConnection() (see #61)

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_connection.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_connection.c
@@ -799,10 +799,6 @@ handleConnection(void* parameter)
 
             Handleset_destroy(handleSet);
 
-            /* Call connection handler */
-            if (self->connectionHandler != NULL)
-                self->connectionHandler(self->connectionHandlerParameter, self, CS104_CONNECTION_CLOSED);
-
         }
     }
     else {
@@ -816,9 +812,13 @@ handleConnection(void* parameter)
 
     Socket_destroy(self->socket);
 
-    DEBUG_PRINT("EXIT CONNECTION HANDLING THREAD\n");
-
     self->running = false;
+
+    /* Call connection handler */
+    if (self->connectionHandler != NULL)
+        self->connectionHandler(self->connectionHandlerParameter, self, CS104_CONNECTION_CLOSED);
+
+    DEBUG_PRINT("EXIT CONNECTION HANDLING THREAD\n");
 
     return NULL;
 }


### PR DESCRIPTION
If user calls CS104_Connection_destroy() in connectionHandler() on CONNECTION_CLOSED event -
two memory errors will occur in handleConnection() because self is not valid anymore
(after returning from connectionHandler() which called CS104_Connection_destroy() before):

(cs104_connection.c:817) Socket_destroy(self->socket);
(cs104_connection.c:821) self->running = false;

So, it's necessary to call connectionHandler() with CONNECTION_CLOSED event right before exiting
from handleConnection().

Fixes https://github.com/mz-automation/lib60870/issues/61