### PR TITLE
In bus architecture this parameter is very important.

### DIFF
--- a/lib60870-C/src/iec60870/link_layer/link_layer.c
+++ b/lib60870-C/src/iec60870/link_layer/link_layer.c
@@ -476,7 +476,7 @@ llsu_setState(LL_Sec_Unb self, LinkLayerState newState)
         self->state = newState;
 
         if (self->stateChangedHandler)
-            self->stateChangedHandler(self->stateChangedHandlerParameter, -1, newState);
+            self->stateChangedHandler(self->stateChangedHandlerParameter, self->_linkLayer.address, newState);
     }
 }
 


### PR DESCRIPTION
In bus architecture this parameter is very important.
Checked when working with more than two saves. 