### PR TITLE
Install also hal_base.h as part of install step

### DIFF
--- a/lib60870-C/Makefile
+++ b/lib60870-C/Makefile
@@ -62,6 +62,7 @@ LIB_API_HEADER_FILES = src/hal/inc/hal_time.h
 LIB_API_HEADER_FILES += src/hal/inc/hal_thread.h
 LIB_API_HEADER_FILES += src/hal/inc/hal_socket.h
 LIB_API_HEADER_FILES += src/hal/inc/hal_serial.h
+LIB_API_HEADER_FILES += src/hal/inc/hal_base.h
 LIB_API_HEADER_FILES += src/inc/api/cs101_information_objects.h
 LIB_API_HEADER_FILES += src/inc/api/cs101_master.h
 LIB_API_HEADER_FILES += src/inc/api/cs101_slave.h


### PR DESCRIPTION
As hal_base.h is used since some time by src/hal/inc/tls_config.h it should also be part of the installed include files.