### PR TITLE
Generate and install a pkg-config file

### DIFF
--- a/lib60870-C/src/CMakeLists.txt
+++ b/lib60870-C/src/CMakeLists.txt
@@ -152,6 +152,12 @@ IF(UNIX)
          -lm
      )
   ENDIF (CONFIG_SYSTEM_HAS_CLOCK_GETTIME)
+
+  configure_file(
+    ${CMAKE_CURRENT_LIST_DIR}/lib60870.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/lib60870.pc @ONLY
+  )
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib60870.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/pkgconfig")
 ENDIF(UNIX)
 IF(MINGW)
   target_link_libraries(lib60870-shared ws2_32 iphlpapi)

--- a/lib60870-C/src/lib60870.pc.in
+++ b/lib60870-C/src/lib60870.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@/bin
+libdir=@CMAKE_INSTALL_PREFIX@/lib
+sharedlibdir=@CMAKE_INSTALL_PREFIX@/lib
+includedir=@CMAKE_INSTALL_PREFIX@/include
+
+Name: @PROJECT_NAME@
+Description: @CPACK_PACKAGE_DESCRIPTION@
+Version: @LIB_VERSION_MAJOR@.@LIB_VERSION_MINOR@.@LIB_VERSION_PATCH@
+
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -llib60870
+Cflags: -I${includedir}


### PR DESCRIPTION
Add a pkg-config file when installing as a shared library.

This is similar to another PR on libiec61850: 
https://github.com/mz-automation/libiec61850/pull/37