### PR TITLE
fix use-after-free in cs104connection closing

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_connection.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_connection.c
@@ -1031,23 +1031,25 @@ handleConnection(void* parameter)
 
         self->conState = STATE_IDLE;
 
+        self->running = false;
+
 #if (CONFIG_USE_SEMAPHORES == 1)
         Semaphore_post(self->conStateLock);
 #endif /* (CONFIG_USE_SEMAPHORES == 1) */
     }
     else {
     	DEBUG_PRINT("Failed to create socket\n");
+
+#if (CONFIG_USE_SEMAPHORES == 1)
+        Semaphore_wait(self->conStateLock);
+#endif /* (CONFIG_USE_SEMAPHORES == 1) */
+
+        self->running = false;
+
+#if (CONFIG_USE_SEMAPHORES == 1)
+        Semaphore_post(self->conStateLock);
+#endif /* (CONFIG_USE_SEMAPHORES == 1) */
     }
-
-#if (CONFIG_USE_SEMAPHORES == 1)
-    Semaphore_wait(self->conStateLock);
-#endif /* (CONFIG_USE_SEMAPHORES == 1) */
-
-    self->running = false;
-
-#if (CONFIG_USE_SEMAPHORES == 1)
-    Semaphore_post(self->conStateLock);
-#endif /* (CONFIG_USE_SEMAPHORES == 1) */
 
     /* Call connection handler */
     if ((event == CS104_CONNECTION_CLOSED) || (event == CS104_CONNECTION_FAILED)) {


### PR DESCRIPTION
In case a connection is closed by the server while the client is trying to send a command there is a race condition that the CS104Connection property running is still true, but the socket is already freed.

1. The server closes the connection and the handleConnection thread locks conStateLock to free the socket
2. handleConnection thread unlocks conStateLock
3. Client sends a command and tests for isRunning, locks and unlocks conStateLock
4. isRunning returns true, so the client tries to send command via sendASDUInternal, locks conStateLock
5. writeToSocket tries to write to freed socket -> SEGFAULT
6. handleConnection thread is waiting for the conStateLock to set running to false 
7. handleConnection thread triggers the CONNECTION_CLOSED event

Therefore I suggest making the socket closing and setting the running state to false atomic by moving the running=false into the same semaphore block instead of using two sequential semaphore blocks.

```cpp
#if (CONFIG_USE_THREADS == 1)
static void*
handleConnection(void* parameter)
{
    CS104_Connection self = (CS104_Connection) parameter;

    CS104_ConnectionEvent event = CS104_CONNECTION_OPENED;

    resetConnection(self);

    self->socket = TcpSocket_create();

    if (self->socket) {

      // [...] CODE SHORTENED FOR READABILITY

      self->running = true;

      // [...] CODE SHORTENED FOR READABILITY

#if (CONFIG_USE_SEMAPHORES == 1)
        Semaphore_wait(self->conStateLock);
#endif /* (CONFIG_USE_SEMAPHORES == 1) */

      // [...] CODE SHORTENED FOR READABILITY

    #if (CONFIG_CS104_SUPPORT_TLS == 1)
        if (self->tlsSocket)
            TLSSocket_close(self->tlsSocket);
    #endif

        Socket_destroy(self->socket);

        self->conState = STATE_IDLE;

        ///// NEW POSITION
        self->running = false;

#if (CONFIG_USE_SEMAPHORES == 1)
        Semaphore_post(self->conStateLock);
#endif /* (CONFIG_USE_SEMAPHORES == 1) */
    }
    else {
    	DEBUG_PRINT("Failed to create socket\n");
    }

    ///// OLD POSITION

    /* Call connection handler */
    if ((event == CS104_CONNECTION_CLOSED) || (event == CS104_CONNECTION_FAILED)) {
        if (self->connectionHandler)
            self->connectionHandler(self->connectionHandlerParameter, self, event);
    }

    return NULL;
}
#endif /* (CONFIG_USE_THREADS == 1) */`

```

I wasn't sure if setting running=false inside the last else-block is really necessary because it should not have been set to true, but to make sure the behavior stays the same I moved the semaphore-locked setting running to false into the else-block as well  in my PR.