### PR TITLE
fix segfault on failing tls reconnect

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_connection.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_connection.c
@@ -1021,8 +1021,10 @@ handleConnection(void* parameter)
         }
 
     #if (CONFIG_CS104_SUPPORT_TLS == 1)
-        if (self->tlsSocket)
-            TLSSocket_close(self->tlsSocket);
+        if (self->tlsSocket) {
+          TLSSocket_close(self->tlsSocket);
+          self->tlsSocket = NULL;
+        }
     #endif
 
         Socket_destroy(self->socket);


### PR DESCRIPTION
There is a potential segmentation fault in a thread-based TLS connection.
I can reproduce the segmentation fault as follows:

1. The client successfully connects to the server (create tlsSocket)
2. The server goes offline and closes the connection
3. The client destroys the tlsSocket
4. The client tries to reconnect, but reconnect fails (skip creation of tlsSocket)
5. The client tries to destroy the tlsSocket again, because the pointer was never set to NULL

