### PR TITLE
trigger CS104_CONNECTION_FAILED event, if tlsSocket fails

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_connection.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_connection.c
@@ -865,7 +865,7 @@ handleConnection(void* parameter)
 {
     CS104_Connection self = (CS104_Connection) parameter;
 
-    CS104_ConnectionEvent event = CS104_CONNECTION_OPENED;
+    CS104_ConnectionEvent event = CS104_CONNECTION_FAILED;
 
     resetConnection(self);
 
@@ -1015,9 +1015,6 @@ handleConnection(void* parameter)
 #if (CONFIG_USE_SEMAPHORES == 1)
             Semaphore_post(self->conStateLock);
 #endif /* (CONFIG_USE_SEMAPHORES == 1) */
-
-            /* register CLOSED event */
-            event = CS104_CONNECTION_FAILED;
         }
 
 #if (CONFIG_USE_SEMAPHORES == 1)
@@ -1064,10 +1061,8 @@ handleConnection(void* parameter)
     }
 
     /* Call connection handler */
-    if ((event == CS104_CONNECTION_CLOSED) || (event == CS104_CONNECTION_FAILED)) {
-        if (self->connectionHandler)
-            self->connectionHandler(self->connectionHandlerParameter, self, event);
-    }
+    if (self->connectionHandler)
+        self->connectionHandler(self->connectionHandlerParameter, self, event);
 
     return NULL;
 }


### PR DESCRIPTION
### Issue
When using **CS104_Connection_connectAsync()** in combination with TLS, the connectionHandler callback does not trigger the **CS104_CONNECTION_FAILED** event as expected.

### Expected behavior
![image](https://github.com/user-attachments/assets/70df41ac-3783-4276-9f24-bbd73136f3fd)


### Description
Previously, the thread function handleConnection() failed to trigger the CS104_CONNECTION_FAILED event if the tlsSocket creation was unsuccessful.

```c++
static void*
handleConnection(void* parameter)
{
    CS104_Connection self = (CS104_Connection) parameter;

    CS104_ConnectionEvent event = CS104_CONNECTION_OPENED;

    resetConnection(self);

    self->socket = TcpSocket_create();

    if (self->socket) {
//     [...] code skipped for readability

        if (Socket_connect(self->socket, self->hostname, self->tcpPort)) {

//         [...] code skipped for readability

            if (self->tlsConfig != NULL) {
                self->tlsSocket = TLSSocket_create(self->socket, self->tlsConfig, false);

                if (self->tlsSocket)
                    self->running = true;
                else
                    self->failure = true;  // <--- this is the problematic case... NOT RUNNING and therefore NO EVENT
            }
            else
                self->running = true;

//     [...] code skipped for readability

            if (isRunning(self)) {

//             [...] code skipped for readability

                /* Call connection handler */
                if (self->connectionHandler)
                    self->connectionHandler(self->connectionHandlerParameter, self, CS104_CONNECTION_OPENED);

//             [...] code skipped for readability

                /* register CLOSED event */
                event = CS104_CONNECTION_CLOSED;
            }
        }
        else {

//         [...] code skipped for readability

            /* register CLOSED event */
            event = CS104_CONNECTION_FAILED;
        }

// [...] code skipped for readability

    /* Call connection handler */
    if ((event == CS104_CONNECTION_CLOSED) || (event == CS104_CONNECTION_FAILED)) {
        if (self->connectionHandler)
            self->connectionHandler(self->connectionHandlerParameter, self, event);
    }

    return NULL;
}
```

To address this, instead of adding an additional exception handler, the proposed solution sets CS104_CONNECTION_FAILED as the default event unless the connection is successfully established.