### PR TITLE
- fixed slave performance issues

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_slave.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_slave.c
@@ -3112,7 +3112,7 @@ connectionHandlingThread(void* parameter)
          * was received. Otherwise wait to save CPU time.
          */
         if (isAsduWaiting)
-            socketTimeout = 0;
+            socketTimeout = 5;
         else
             socketTimeout = 100;
 


### PR DESCRIPTION
I was testing the examples and I realized that slave 104 consumed 100% of the CPU when sending ASDUS to an established connection. 
![image](https://github.com/user-attachments/assets/56c6f8fd-7219-4f27-9781-4a5279aac2a2)

`perf report`

![image](https://github.com/user-attachments/assets/404afac6-600d-48d8-87b4-f7ff312b77bb)



In previous versions this did not happen. I investigated a bit and got to the root of the problem.
```c
diff --git a/lib60870-C/src/iec60870/cs104/cs104_slave.c b/lib60870-C/src/iec60870/cs104/cs104_slave.c
index ea500de..975ed4a 100644
--- a/lib60870-C/src/iec60870/cs104/cs104_slave.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_slave.c
@@ -3112,7 +3112,7 @@ connectionHandlingThread(void* parameter)
          * was received. Otherwise wait to save CPU time.
          */
         if (isAsduWaiting)
-            socketTimeout = 0;
+            socketTimeout = 5;
         else
             socketTimeout = 100;
```

In previous versions the minimum value of `socketTimeout` was `1` but at some point it was changed to `0` which caused the loop where it is located to consume all the CPU, I set the minimum value to `5` to be a little reserved



