### PR TITLE
fix thread_win32.c Semaphore_create to use initialValue parameter

### DIFF
--- a/lib60870-C/src/hal/thread/win32/thread_win32.c
+++ b/lib60870-C/src/hal/thread/win32/thread_win32.c
@@ -89,7 +89,7 @@ Thread_sleep(int millies)
 Semaphore
 Semaphore_create(int initialValue)
 {
-    HANDLE self = CreateSemaphore(NULL, 1, 1, NULL);
+    HANDLE self = CreateSemaphore(NULL, initialValue, LONG_MAX, NULL);
 
     return self;
 }


### PR DESCRIPTION
- Modify semaphore creation to use 'initialValue' instead of fixed value 1.